### PR TITLE
Fix cask definition for "cask :v1 => 'token'" deprecated usage.

### DIFF
--- a/Casks/hhkb-professional-driver.rb
+++ b/Casks/hhkb-professional-driver.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'hhkb-professional-driver' do
+cask 'hhkb-professional-driver' do
   version '3.0.1'
   sha256 '91d549cc88b690a04d30c5939029e7b46a1a22e16b17d1821665b9c2f0da46ea'
 

--- a/Casks/mono-mdk3121.rb
+++ b/Casks/mono-mdk3121.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'mono-mdk3121' do
+cask 'mono-mdk3121' do
   version '3.12.1'
   sha256 '98abc2854e9d0dfafd16c2b9dd27b82eda9e28440f112eded882d51cb56b89d8'
 

--- a/Casks/unity463p2.rb
+++ b/Casks/unity463p2.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'unity463p2' do
+cask 'unity463p2' do
   version '4.6.3p2'
   sha256 'b2c86867864ab9fea636f4d4e91dead95ad20da8b245b117276b1952e60f4af9'
 


### PR DESCRIPTION
Fix cask definition for "cask :v1 => 'token'" deprecated usage.